### PR TITLE
[issue #115] Allow sheets to have multiple styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ startup_back.sh
 cmd/insetmap/server/insetmap
 cmd/insetmap/insetmap/insetmap
 cmd/insetmap/server/insermap_server
+cmd/insetmap/server/server

--- a/atlante/config/README.md
+++ b/atlante/config/README.md
@@ -31,11 +31,21 @@ The webserver has the following properties
 [[filestores]]
 ...
 
+[[styles]]
+   name = "name"
+   location = "url://of/the/style/file"
+   description = "description of the style."
+
+[[styles]]
+   name = "name2"
+   location = "url://of/the/style/file/2"
+   description = "description of the style"
+
 [[sheets]]
 
    name = "50k"
    provider_grid = "postgistDB50k"
-   style = "files://...."
+   styles = ["name","name2"]
    template = "templates/...."
    file_stores = [ "file", "s3" ]
 
@@ -45,7 +55,7 @@ The webserver has the following properties
 * `file_stores`   (string) : [required] the names of file stores to use
 * `name`          (string) : [required] the name of the sheet
 * `provider_grid` (string) : [required] the name of the grid provider
-* `style`         (string) : [required] the style to use for this sheet
+* `styles`         (array of strings) : [optional] the style to use for this sheet, defaults to the first style in global styles
 * `template`      (string) : [required] the template to use 
 * `description`   (string) : [optional] ("") the description for this sheet
 * `dpi`           (int)    : [optional] (144) the DPI to use

--- a/atlante/config/config.go
+++ b/atlante/config/config.go
@@ -32,9 +32,19 @@ type Config struct {
 	// that the user wants
 	FileStores []env.Dict `toml:"file_stores"`
 
+	// Styles are the styles that can be used
+	Styles []Style `toml:"styles" `
 	// metadata holds the metadata from parsing the toml
 	// file
 	metadata toml.MetaData `toml:"-"`
+}
+
+// Style describes information about the various styles that will be
+// available to the system
+type Style struct {
+	Name env.String `toml:"name"`
+	Loc  env.String `toml:"location"`
+	Desc env.String `toml:"description"`
 }
 
 // Webserver represents the config values for the webserver potion
@@ -51,15 +61,16 @@ type Webserver struct {
 
 // Sheet models a sheet in the config file
 type Sheet struct {
-	Name         env.String   `toml:"name"`
-	ProviderGrid env.String   `toml:"provider_grid"`
-	Filestores   []env.String `toml:"file_stores"`
-	DPI          env.Int      `toml:"dpi"`
-	Template     env.String   `toml:"template"`
-	Style        env.String   `toml:"style"`
-	Description  env.String   `toml:"description"`
-	Width        env.Float    `toml:"width"`
-	Height       env.Float    `toml:"height"`
+	Name         env.String     `toml:"name"`
+	ProviderGrid env.String     `toml:"provider_grid"`
+	Filestores   []env.String   `toml:"file_stores"`
+	DPI          env.Int        `toml:"dpi"`
+	Template     env.String     `toml:"template"`
+	Style        env.String     `toml:"style"`
+	Styles       env.StringList `toml:"styles"`
+	Description  env.String     `toml:"description"`
+	Width        env.Float      `toml:"width"`
+	Height       env.Float      `toml:"height"`
 }
 
 // Validate will validate the config and make sure the is valid

--- a/atlante/config/config_test.go
+++ b/atlante/config/config_test.go
@@ -1,18 +1,46 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
+func resetEnv(newEnv map[string]string) (old map[string]string) {
+	envs := os.Environ()
+	old = make(map[string]string, len(envs))
+	for _, s := range envs {
+		for j := 0; j < len(s); j++ {
+			if s[j] == '=' {
+				old[s[:j]] = s[j+1:]
+			}
+		}
+	}
+	os.Clearenv()
+	if newEnv == nil {
+		return old
+	}
+	for k, v := range newEnv {
+		os.Setenv(k, v)
+	}
+	return old
+}
 func TestLoad(t *testing.T) {
 
 	type tcase struct {
-		file   string // This name of the file to load from the testdata directory
-		Err    error  // expected error
-		config Config // Expected Config
+		file   string            // This name of the file to load from the testdata directory
+		Err    error             // expected error
+		config Config            // Expected Config
+		Env    map[string]string // The expected environment.
 	}
 
+	// These test can not run in parallel, as we are modifying the os.Env
 	fn := func(tc tcase) (string, func(*testing.T)) {
 		return tc.file, func(t *testing.T) {
-			//...
+
+			oldEnv := resetEnv(tc.Env)
+			// make sure we clean up after ourselfs
+			defer resetEnv(oldEnv)
+
 		}
 	}
 	tests := []tcase{

--- a/atlante/internal/env/types.go
+++ b/atlante/internal/env/types.go
@@ -91,6 +91,49 @@ func (t *String) UnmarshalTOML(v interface{}) error {
 	return nil
 }
 
+type StringList []string
+
+func StringListPtr(v StringList) *StringList {
+	return &v
+}
+
+// UnmarshalTOML fullfils the the TOMAL interface for unmarshaling the value
+// there are a few types for a string list.
+// if v is a string/inteface{}, then we parse the string and then split the
+// value inside on comma's.
+// if v is a []string, or []interface, we will treat each value as
+// an env.String
+func (t *StringList) UnmarshalTOML(v interface{}) error {
+
+	switch tt := v.(type) {
+	default:
+		var s String
+		if err := s.UnmarshalTOML(v); err != nil {
+			return fmt.Errorf("StringList err: %w", err)
+		}
+		(*t) = append((*t), strings.Split(string(s), ",")...)
+		return nil
+	case []string:
+		for i := range tt {
+			var s String
+			if err := s.UnmarshalTOML(tt[i]); err != nil {
+				return fmt.Errorf("StringList err: %w", err)
+			}
+			(*t) = append((*t), string(s))
+		}
+		return nil
+	case []interface{}:
+		for i := range tt {
+			var s String
+			if err := s.UnmarshalTOML(tt[i]); err != nil {
+				return fmt.Errorf("StringList err: %w", err)
+			}
+			(*t) = append((*t), string(s))
+		}
+		return nil
+	}
+}
+
 type Int int
 
 func IntPtr(v Int) *Int {

--- a/atlante/server/coordinator/README.md
+++ b/atlante/server/coordinator/README.md
@@ -1,0 +1,11 @@
+# Coordinator
+
+The job of the coordinator is to act as a queue for jobs.
+The coordinator has two important jobs:
+
+1. Make sure jobs that are the same receive the same JobID and are
+not requeued into the system.
+2. Provide information about Jobs that are currently in the system.
+
+The coordinator does not enqueue a job just create a new job or return
+an already existing job based on the information given to it.

--- a/atlante/server/coordinator/coordinator.go
+++ b/atlante/server/coordinator/coordinator.go
@@ -18,16 +18,17 @@ type Job struct {
 	JobID string `json:"job_id"`
 	// QJobID is the job id returned by the queue when
 	// the item was enqueued
-	QJobID     string       `json:"-"`
-	MdgID      string       `json:"mdgid"`
-	MdgIDPart  uint32       `json:"sheet_number,omitempty"`
-	SheetName  string       `json:"sheet_name"`
-	Status     field.Status `json:"status"`
-	EnqueuedAt time.Time    `json:"enqueued_at"`
-	UpdatedAt  time.Time    `json:"updated_at"`
-	AJob       *atlante.Job `json:"-"`
-	PDF        string       `json:"pdf_url"`
-	LastGen    string       `json:"last_generated"` // RFC 3339 format
+	QJobID        string       `json:"-"`
+	MdgID         string       `json:"mdgid"`
+	MdgIDPart     uint32       `json:"sheet_number,omitempty"`
+	SheetName     string       `json:"sheet_name"`
+	StyleLocation string       `json:"style_location"`
+	Status        field.Status `json:"status"`
+	EnqueuedAt    time.Time    `json:"enqueued_at"`
+	UpdatedAt     time.Time    `json:"updated_at"`
+	AJob          *atlante.Job `json:"-"`
+	PDF           string       `json:"pdf_url"`
+	LastGen       string       `json:"last_generated"` // RFC 3339 format
 }
 
 type Provider interface {
@@ -38,10 +39,10 @@ type Provider interface {
 
 	// FindJob will look for a jobs described by the given atlante.Job (MDGID/SheetName), this should return only the latest
 	// two jobs.
-	FindByJob(job *atlante.Job) (jobs []*Job)
+	FindByJob(job *atlante.Job, defaultStyleLocation string) (jobs []*Job)
 
-	// FindJobID will attempt to locate the job by the given jobId, if a job is found non-nil job will be returned. If an error
-	// occurs then err will be non-nil. If job is not found, the both jb and err will be nil
+	// FindJobID will attempt to locate the job by the given jobId, if a job is found non-nil job will be returned and found will be true.
+	// If the job is not found; a nil job will be return and found will be false.
 	FindByJobID(jobid string) (jobs *Job, found bool)
 
 	// UpdateField will attempt to update the job field info for the given job.
@@ -58,22 +59,27 @@ func NewJob(jobID string, ajob *atlante.Job) *Job {
 	t := time.Now()
 	var mdgid grids.MDGID
 	var sheetName string
+	var styleLocation string
 
 	if ajob != nil {
 		if ajob.Cell.Mdgid != nil {
 			mdgid = *ajob.Cell.Mdgid
 		}
 		sheetName = ajob.SheetName
+		if ajob.MetaData != nil {
+			styleLocation = ajob.MetaData["styleLocation"]
+		}
 	}
 
 	return &Job{
-		JobID:      jobID,
-		MdgID:      mdgid.Id,
-		MdgIDPart:  mdgid.Part,
-		SheetName:  sheetName,
-		Status:     field.Status{field.Requested{}},
-		EnqueuedAt: t,
-		UpdatedAt:  t,
-		AJob:       ajob,
+		JobID:         jobID,
+		MdgID:         mdgid.Id,
+		MdgIDPart:     mdgid.Part,
+		SheetName:     sheetName,
+		StyleLocation: styleLocation,
+		Status:        field.Status{field.Requested{}},
+		EnqueuedAt:    t,
+		UpdatedAt:     t,
+		AJob:          ajob,
 	}
 }

--- a/atlante/server/coordinator/logger/logger.go
+++ b/atlante/server/coordinator/logger/logger.go
@@ -95,14 +95,14 @@ func (p *Provider) UpdateField(job *coordinator.Job, fields ...field.Value) erro
 	return nil
 }
 
-func (p *Provider) FindByJob(job *atlante.Job) (jobs []*coordinator.Job) {
+func (p *Provider) FindByJob(job *atlante.Job, defaultStyleLocation string) (jobs []*coordinator.Job) {
 	if job == nil {
 		log.Infof("job is nil")
 		return nil
 	}
 	log.Infof("looking for job via sheet: %v mdgid: %v ", job.SheetName, job.Cell.Mdgid.AsString())
 	if p == nil || p.Provider != nil {
-		return p.Provider.FindByJob(job)
+		return p.Provider.FindByJob(job, defaultStyleLocation)
 	}
 	return nil
 }

--- a/atlante/server/coordinator/null/null.go
+++ b/atlante/server/coordinator/null/null.go
@@ -29,15 +29,15 @@ func (Provider) NewJob(job *atlante.Job) (jb *coordinator.Job, err error) {
 	return coordinator.NewJob(jbID, job), nil
 }
 
-func (Provider) UpdateField(job *coordinator.Job, fields ...field.Value) error {
+func (Provider) UpdateField(*coordinator.Job, ...field.Value) error {
 	return nil
 }
 
-func (Provider) FindByJob(job *atlante.Job) (jobs []*coordinator.Job) {
+func (Provider) FindByJob(*atlante.Job, string) (jobs []*coordinator.Job) {
 	return nil
 }
 
-func (Provider) FindByJobID(jobid string) (jb *coordinator.Job, found bool) {
+func (Provider) FindByJobID(string) (jb *coordinator.Job, found bool) {
 	return nil, false
 }
 func (Provider) Jobs(uint) ([]*coordinator.Job, error) {

--- a/atlante/server/coordinator/postgresql/docs/jobs_00.sql
+++ b/atlante/server/coordinator/postgresql/docs/jobs_00.sql
@@ -1,14 +1,16 @@
-CREATE EXTENSION IF NOT EXISTS postgis ;
+CREATE EXTENSION IF NOT EXISTS postgis;
 
 CREATE TABLE jobs (
-    id SERIAL PRIMARY KEY,
-    mdgid TEXT NOT NULL,
+    id serial PRIMARY KEY,
+    mdgid text NOT NULL,
     sheet_number integer DEFAULT 0,
-    sheet_name TEXT NOT NULL,
-    queue_id TEXT,
-    job_data TEXT,
-    bounds geometry(Polygon, 4326) NOT NULL,
-    created TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+    sheet_name text NOT NULL,
+    queue_id text,
+    job_data text,
+    bounds geometry(polygon, 4326) NOT NULL,
+    style_name text DEFAULT '',
+    style_location text DEFAULT '',
+    created timestamp WITH time zone DEFAULT NOW()
 );
 
 CREATE INDEX ON jobs (mdgid);
@@ -19,31 +21,37 @@ CREATE INDEX ON jobs (sheet_name);
 
 CREATE INDEX ON jobs (queue_id);
 
+CREATE INDEX ON jobs (style_location);
+
 CREATE INDEX bounds_polygon_idx ON jobs USING GIST (bounds);
 
-
 CREATE TABLE job_statuses (
-    id SERIAL PRIMARY KEY,
-    job_id INTEGER NOT NULL,
-    status TEXT NOT NULL,
-    description TEXT NOT NULL,
-    created TIMESTAMP WITH TIME ZONE default NOW()
+    id serial PRIMARY KEY,
+    job_id integer NOT NULL,
+    status text NOT NULL,
+    description text NOT NULL,
+    created timestamp WITH time zone DEFAULT NOW()
 );
-
 
 CREATE INDEX ON job_statuses (job_id);
 
 -- Find job by job id
-SELECT 
+SELECT
     job.mdgid,
     job.sheet_number,
     job.sheet_name,
+    job.style_location,
     job.queue_id,
-    job.created as enqueued,
+    job.created AS enqueued,
     jobstatus.status,
     jobstatus.description,
-    jobstatus.created as updated
-FROM jobs AS job
-JOIN job_statuses AS jobstatus ON job.id = jobstatus.job_id
-WHERE job.id = $1
-ORDER BY jobstatus.id desc limit 1;
+    jobstatus.created AS updated
+FROM
+    jobs AS job
+    JOIN job_statuses AS jobstatus ON job.id = jobstatus.job_id
+WHERE
+    job.id = $1
+ORDER BY
+    jobstatus.id DESC
+LIMIT 1;
+

--- a/atlante/server/coordinator/postgresql/docs/jobs_02.sql
+++ b/atlante/server/coordinator/postgresql/docs/jobs_02.sql
@@ -1,0 +1,6 @@
+ALTER TABLE IF EXISTS jobs
+    ADD COLUMN style_name text DEFAULT '',
+    ADD COLUMN style_location text DEFAULT '';
+
+CREATE INDEX ON jobs (style_location);
+

--- a/atlante/sheet.go
+++ b/atlante/sheet.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-spatial/atlante/atlante/internal/urlutil"
 	"github.com/go-spatial/atlante/atlante/notifiers"
 	"github.com/go-spatial/atlante/atlante/server/coordinator/field"
+	"github.com/go-spatial/atlante/atlante/style"
 	"github.com/prometheus/common/log"
 )
 
@@ -38,8 +39,10 @@ type Sheet struct {
 	DPI uint
 	// Scale value (50000, 5000, etc...)
 	Scale uint
-	// URL to the style file
-	Style string
+
+	// Styles is the name of the style to use from the global style set.
+	Styles style.Provider
+
 	// Template file to use
 	SvgTemplateFilename string
 
@@ -108,7 +111,7 @@ func loadTemplateDir(t *template.Template, location *url.URL) (*template.Templat
 }
 
 // NewSheet returns a new sheet
-func NewSheet(name string, provider grids.Provider, dpi uint, desc string, style string, svgTemplateFilename *url.URL, fs filestore.Provider) (*Sheet, error) {
+func NewSheet(name string, provider grids.Provider, dpi uint, desc string, stylelist style.Provider, svgTemplateFilename *url.URL, fs filestore.Provider) (*Sheet, error) {
 	var (
 		err error
 		t   *template.Template
@@ -122,7 +125,7 @@ func NewSheet(name string, provider grids.Provider, dpi uint, desc string, style
 		Provider:            provider,
 		DPI:                 dpi,
 		Scale:               uint(scale),
-		Style:               style,
+		Styles:              stylelist,
 		SvgTemplateFilename: svgTemplateFilename.String(),
 		Filestore:           fs,
 		Desc:                desc,

--- a/atlante/style/errors.go
+++ b/atlante/style/errors.go
@@ -1,0 +1,12 @@
+package style
+
+import "fmt"
+
+type ErrAlreadyExists struct {
+	Style Style
+	List  *List
+}
+
+func (err ErrAlreadyExists) Error() string {
+	return fmt.Sprintf("style %v already exists in list", err.Style.Name)
+}

--- a/atlante/style/style.go
+++ b/atlante/style/style.go
@@ -1,0 +1,187 @@
+package style
+
+import (
+	"sort"
+	"sync"
+)
+
+var (
+	global List
+)
+
+type Provider interface {
+	// For will return a url to the style and if it was found.
+	// if name is not found it will return the default style, and false for
+	// found. If name is "", then For should return the default style, with
+	// found being set to true
+	// style should only be an empty style struct if no styles are defined in the system. Then
+	// found should also be false
+	For(name string) (style Style, found bool)
+
+	// Styles returns the list of known styles.
+	Styles() []string
+}
+
+// List holds a set of styles
+type List struct {
+	lck    sync.RWMutex
+	styles []Style
+	idx    map[string]int
+}
+
+// For returns the style in the list with the given name. If the style is not
+// found it the default style will be returned and false.
+func (s *List) For(name string) (Style, bool) {
+	if s == nil {
+		return global.For(name)
+	}
+	s.lck.RLock()
+	defer s.lck.RUnlock()
+	if len(s.styles) == 0 || len(s.idx) == 0 {
+		return Style{}, false
+	}
+	if name == "" {
+		return s.styles[0], true
+	}
+	idx, ok := s.idx[name]
+	return s.styles[idx], ok
+}
+
+// Styles returns the known styles
+func (s *List) Styles() []string {
+	if s == nil {
+		return global.Styles()
+	}
+	names := make([]string, len(s.styles))
+	for i := range s.styles {
+		names[i] = s.styles[i].Name
+	}
+	return names
+}
+
+// Append will add a style to the system
+func (s *List) Append(styles ...Style) error {
+	if s == nil {
+		return global.Append(styles...)
+	}
+	s.lck.Lock()
+	defer s.lck.Unlock()
+	if s.idx == nil {
+		s.idx = make(map[string]int)
+	}
+	for i := range styles {
+		if _, ok := s.idx[styles[i].Name]; ok {
+			return ErrAlreadyExists{
+				Style: styles[i],
+				List:  s,
+			}
+		}
+		s.styles = append(s.styles, styles[i])
+		s.idx[styles[i].Name] = len(s.styles) - 1
+	}
+	return nil
+}
+
+// SubList will return a Style list that will reference the main list and
+// limit the styles to names
+func (s *List) SubList(names ...string) *Sublist {
+
+	if s == nil {
+		return global.SubList(names...)
+	}
+
+	return &Sublist{
+		Names: names,
+		Main:  s,
+	}
+}
+
+// Style describes a style
+type Style struct {
+	Name        string
+	Location    string
+	Description string
+}
+
+// Sublist is a sublist of the main set of list
+type Sublist struct {
+	Names []string
+	Main  Provider
+}
+
+// For will return the Style for the give name
+func (s Sublist) For(name string) (Style, bool) {
+	if len(s.Names) == 0 {
+		return s.Main.For(name)
+	}
+	if name == "" {
+		return s.Main.For(s.Names[0])
+	}
+
+	if len(s.Names) == 1 {
+		sty, _ := s.Main.For(s.Names[0])
+		return sty, name == s.Names[0]
+	}
+
+	// make sure name is in our style list
+	for i := range s.Names {
+		if s.Names[i] == name {
+			return s.Main.For(name)
+		}
+	}
+
+	// if the name is in the our list return the default
+	// with false for found
+	sty, _ := s.Main.For(s.Names[0])
+	return sty, false
+}
+
+// Styles returns the current styles names in the list
+func (s Sublist) Styles() []string {
+
+	var names []string
+	mnames := s.Main.Styles()
+	if len(mnames) == 0 {
+		return []string{}
+	}
+	lookup := make(map[string]bool, len(mnames))
+	for _, name := range mnames {
+		lookup[name] = true
+	}
+
+	for _, name := range s.Names {
+		if lookup[name] {
+			names = append(names, name)
+		}
+	}
+
+	sort.Strings(names)
+	return names
+}
+
+// SubList generates a sublist based on the names given
+func (s *Sublist) SubList(names ...string) *Sublist {
+	if s == nil {
+		return global.SubList(names...)
+	}
+	return &Sublist{
+		Names: names,
+		Main:  s,
+	}
+}
+
+// Append the style to the global list of styles
+func Append(styles ...Style) error {
+	return global.Append(styles...)
+}
+
+// SubList returns a sublist based on the global List
+func SubList(names ...string) *Sublist { return global.SubList(names...) }
+
+// Styles returns the last of styles in the global style list
+func Styles() []string {
+	return global.Styles()
+}
+
+// For returns the style for the given name and if it was found in the global registary
+func For(name string) (Style, bool) { return global.For(name) }


### PR DESCRIPTION
The config now allows one to define all the styles that will be used
and assign them a name and description in addition to the location.

Then each sheet in the config can use the `styles` attribute to define
the order and which styles defined in the global section will be used
for this sheet. The default style is always the first style defined,
in each list.

If a sheet does not define a set of styles to use, it will inheriate
the list of global styles.

A new field has been added to the jobs js called 'style_name' that can
be used to indicate which style the sheet should use.

In the CLI styles defined in the config can be listed. Also, sheet info
now include the list of style avilable and their descriptions.

There is a new SQL that needs to be applied before this binary can be
deployed. This change will not effect the old version. This version
is also compatiable with the old config file. New Styles will be
generated for each sheet using the old `style` option. If `style` and
`styles` are both found in a sheet configuration only the `styles` will
be used. In addition no warning will be given, unlike if only `style` is
found.

fixes #115