### PR TITLE
Updated so that generated grid Labels are labeled from the top

### DIFF
--- a/atlante/template/grating/grating.go
+++ b/atlante/template/grating/grating.go
@@ -18,7 +18,7 @@ var LabelLetters = [...]string{
 	// Skip I and L (looks like 1 i l), O and Q (looks like 0, 6, o , q), S (looks like 5, s)
 	// 0 1 2 3 4 5 6 7 8 9
 	"A", "B", "C", "D", "E", "F", "G", "H", "J", "K",
-	"M", "N", "P", "R", "T", "U", "V", "W", "Y", "Z",
+	"M", "N", "P", "R", "T", "U", "V", "W", "X", "Y", "Z",
 }
 
 type Grating struct {
@@ -33,7 +33,8 @@ type Grating struct {
 	// have to modify the value by to get the row or col line
 	Width, Height float64
 
-	FlipY bool
+	FlipY      bool
+	FlipYLabel bool
 }
 
 func Squarish(width, height float64, division uint) (widthDivision, heightDivision float64, rows, cols uint) {
@@ -89,31 +90,21 @@ func (grate *Grating) labelForRow(row int) string {
 		buff   strings.Builder
 		lblLen = len(LabelLetters)
 	)
+
 	if row < lblLen {
 		return LabelLetters[row]
 	}
-	prelbl := grate.labelForRow(row / lblLen)
+	prelbl := grate.labelForRow((row / lblLen) - 1)
 	buff.WriteString(prelbl)
 	buff.WriteString(LabelLetters[row%lblLen])
 	return buff.String()
 }
 func (grate *Grating) LabelForRow(row int) string {
-	if row < 0 || row > int(grate.Rows) {
+	if grate == nil || row < 0 || row > int(grate.Rows) {
 		return ""
 	}
-	var (
-		buff   strings.Builder
-		lblLen = len(LabelLetters)
-	)
-	if row < lblLen {
-		if int(grate.Rows) >= lblLen {
-			// Need to add the first letter
-			for i := 1; i < int(grate.Rows)/lblLen; i++ {
-				buff.WriteString(LabelLetters[0])
-			}
-		}
-		buff.WriteString(LabelLetters[row])
-		return buff.String()
+	if !grate.FlipYLabel {
+		row = int(grate.Rows) - row
 	}
 	return grate.labelForRow(row)
 }

--- a/atlante/template/grating/grating_test.go
+++ b/atlante/template/grating/grating_test.go
@@ -1,0 +1,73 @@
+package grating
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestLabelForRow(t *testing.T) {
+
+	type tcase struct {
+		Grating *Grating
+		Rows    []int
+		Labels  []string
+	}
+
+	fn := func(tc tcase) func(*testing.T) {
+		return func(t *testing.T) {
+
+			for i := range tc.Rows {
+				t.Run(fmt.Sprintf("%v row %v", i, tc.Rows[i]),
+					func(t *testing.T) {
+						lbl := tc.Grating.LabelForRow(tc.Rows[i])
+						if lbl != tc.Labels[i] {
+							t.Errorf("label, expected %s got %s", tc.Labels[i], lbl)
+						}
+					},
+				)
+			}
+		}
+	}
+
+	seq := func(start, end int) (r []int) {
+
+		if start > end {
+			start, end = end, start
+		}
+
+		r = make([]int, 0, end-start)
+
+		for i := start; i <= end; i++ {
+			r = append(r, i)
+		}
+		return r
+	}
+
+	tests := map[string]tcase{
+		"Rows: 10 row: 1": {
+			Grating: &Grating{Rows: 10},
+			Rows:    seq(0, 10),
+			Labels:  strings.Split("M K J H G F E D C B A", " "),
+		},
+		"Rows: 22 row: 1": {
+			Grating: &Grating{Rows: 23},
+			Rows:    seq(0, 5),
+			Labels:  strings.Split("AC AB AA Z Y X", " "),
+		},
+		"Rows: 10 row: 1 FlipLabel": {
+			Grating: &Grating{Rows: 10, FlipYLabel: true},
+			Rows:    seq(0, 10),
+			Labels:  strings.Split("A B C D E F G H J K M", " "),
+		},
+		"Rows: 10 row: 11": {
+			Grating: &Grating{Rows: 10},
+			Rows:    []int{11},
+			Labels:  []string{""},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, fn(tc))
+	}
+}


### PR DESCRIPTION
Current labeling starts at the bottom of the grid instead of the top. Now it will start from the top, and flow down. Also, fixed labeling so that wrap to AA  and not BA.
